### PR TITLE
Use a valid list retriever for the global Update() function

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -24,3 +24,10 @@ func TestNewGitHubListRetriever(t *testing.T) {
 		t.Fatalf("GetList(tag) got err %v, want nil", err)
 	}
 }
+
+func TestUpdate(t *testing.T) {
+	err := Update()
+	if err != nil {
+		t.Fatalf("Got err when updating %v", err)
+	}
+}

--- a/listretriever.go
+++ b/listretriever.go
@@ -81,7 +81,13 @@ func (gh gitHubListRetriever) GetLatestReleaseTag() (string, error) {
 func (gh gitHubListRetriever) GetList(release string) (io.Reader, error) {
 	var url = fmt.Sprintf(publicSuffixURL, release)
 
-	var res, err = gh.client.Get(url)
+	// Just in case a nil client was passed, use the default http client.
+	client := http.DefaultClient
+	if gh.client != nil {
+		client = gh.client
+	}
+
+	var res, err = client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving last revision of the PSL(%s): %s", release, err.Error())
 	}

--- a/listretriever.go
+++ b/listretriever.go
@@ -53,9 +53,18 @@ func NewGitHubListRetriever(client *http.Client) ListRetriever {
 	}
 }
 
+func (gh gitHubListRetriever) Client() *http.Client {
+	// Just in case a nil client was passed, use the default http client.
+	client := http.DefaultClient
+	if gh.client != nil {
+		client = gh.client
+	}
+	return client
+}
+
 // GetLatestReleaseTag retrieves the tag for the latest commit on Public Suffix List repo
 func (gh gitHubListRetriever) GetLatestReleaseTag() (string, error) {
-	var res, err = gh.client.Get(gitCommitURL)
+	var res, err = gh.Client().Get(gitCommitURL)
 	if err != nil {
 		return "", fmt.Errorf("error while retrieving last release information from github: %s", err.Error())
 	}
@@ -81,13 +90,7 @@ func (gh gitHubListRetriever) GetLatestReleaseTag() (string, error) {
 func (gh gitHubListRetriever) GetList(release string) (io.Reader, error) {
 	var url = fmt.Sprintf(publicSuffixURL, release)
 
-	// Just in case a nil client was passed, use the default http client.
-	client := http.DefaultClient
-	if gh.client != nil {
-		client = gh.client
-	}
-
-	var res, err = client.Get(url)
+	var res, err = gh.Client().Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving last revision of the PSL(%s): %s", release, err.Error())
 	}

--- a/publicsuffix.go
+++ b/publicsuffix.go
@@ -40,6 +40,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"regexp"
 	"strings"
 	"sync"
@@ -153,7 +154,7 @@ func Read(r io.Reader) error {
 // 		https://github.com/publicsuffix/list
 //
 func Update() error {
-	return UpdateWithListRetriever(gitHubListRetriever{})
+	return UpdateWithListRetriever(gitHubListRetriever{http.DefaultClient})
 }
 
 // UpdateWithListRetriever attempts to update the internal public suffix list


### PR DESCRIPTION
The last update to the list retriever, in order to use a custom client, passed the tests provided but was still broken since it was using a nil http.Client for the provided Update() function which broke the library. This change fixes this issue, and adds an integration test to at least call Update() to ensure that it doesn't get silently broken again.